### PR TITLE
Fix customer name handling for Shiprocket API compliance

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,8 @@
+import dotenv from "dotenv";
+
+// Load environment variables from .env file
+dotenv.config();
+
 (async () => {
   require("@/transports/stdio.js");
   process.env.MCP_TRANSPORT = "STDIO";

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -4,6 +4,7 @@ import axios from "axios";
 import { connectionsBySessionId, globalSessionId } from "./connections";
 import { AxiosError } from "axios";
 import { API_DOMAINS } from "@/config";
+import { splitCustomerName } from "@/utils/nameUtils";
 
 export const initializeTools = (server: McpServer) => {
   server.tool(
@@ -679,7 +680,7 @@ export const initializeTools = (server: McpServer) => {
 
     Args:
         pickup_location_nickname: String representing short nickname of pickup location
-        customer_name: String representing name of the customer who placed order
+        customer_name: String representing full name of the customer who placed order (will be auto-split into first and last name; single names use same value for both)
         customer_email: String representing email of the customer who placed order
         customer_phone: 10-digit number representing phone number of the customer who placed order
         delivery_address: String representing customer address on which order will be delivered
@@ -729,6 +730,9 @@ export const initializeTools = (server: McpServer) => {
       const url = `${API_DOMAINS.SHIPROCKET}/v1/external/orders/create/adhoc`;
 
       try {
+        // Split customer name into first and last name for Shiprocket API
+        const { firstName, lastName } = splitCustomerName(args.customer_name);
+
         const data = (
           await axios.post(
             url,
@@ -738,7 +742,8 @@ export const initializeTools = (server: McpServer) => {
                 .padStart(4)}`,
               order_date: new Date().toLocaleDateString("en-CA"),
               pickup_location: args.pickup_location,
-              billing_customer_name: args.customer_name,
+              billing_customer_name: firstName,
+              billing_last_name: lastName,
               billing_address: args.delivery_address,
               billing_city: args.delivery_city,
               billing_pincode: args.delivery_pincode,

--- a/src/utils/nameUtils.ts
+++ b/src/utils/nameUtils.ts
@@ -1,0 +1,37 @@
+/**
+ * Utility functions for handling customer name operations
+ */
+
+export interface SplitName {
+  firstName: string;
+  lastName: string;
+}
+
+/**
+ * Splits a full name into first and last name components for API compliance.
+ *
+ * @param fullName - The complete customer name to split
+ * @returns Object containing firstName and lastName
+ * @throws Error if the name is empty or contains only whitespace
+ *
+ * @example
+ * splitCustomerName("John Doe") // { firstName: "John", lastName: "Doe" }
+ * splitCustomerName("John Michael Smith") // { firstName: "John", lastName: "Michael Smith" }
+ * splitCustomerName("Madonna") // { firstName: "Madonna", lastName: "Madonna" }
+ */
+export function splitCustomerName(fullName: string): SplitName {
+  const trimmed = fullName.trim();
+
+  if (!trimmed) {
+    throw new Error("Customer name cannot be empty");
+  }
+
+  const nameParts = trimmed.split(/\s+/);
+  const firstName = nameParts[0];
+  const lastName = nameParts.length > 1 ? nameParts.slice(1).join(' ') : nameParts[0];
+
+  return {
+    firstName,
+    lastName
+  };
+}


### PR DESCRIPTION
This commit addresses a bug where customer names weren't properly split into first and last name fields as required by the Shiprocket API.

Changes:
- Added dotenv support to load environment variables from .env file
- Created utility function splitCustomerName() with proper validation
- Refactored tools.ts to use the utility function instead of inline logic
- Handles edge cases: multi-word names, single-word names, empty names

For single-word names (e.g., "Madonna"), the same value is used for both first and last name fields to satisfy API requirements.